### PR TITLE
do not require cmf.ManagePortal to add or edit the portlets

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,7 @@ Changelog
 
 1.34
 ----
+* Do not require cmf.ManagePortal to add or edit the portlet [erral]
 
 1.33
 ----

--- a/src/qi/portlet/TagClouds/configure.zcml
+++ b/src/qi/portlet/TagClouds/configure.zcml
@@ -27,8 +27,6 @@
          name="qi.portlet.TagClouds.TagCloudPortlet"
          interface=".tagcloudportlet.ITagCloudPortlet"
          assignment=".tagcloudportlet.Assignment"
-         view_permission="zope2.View"
-         edit_permission="cmf.ManagePortal"
          renderer=".tagcloudportlet.Renderer"
          addview=".tagcloudportlet.AddForm"
          editview=".tagcloudportlet.EditForm"


### PR DESCRIPTION
do not require cmf.ManagePortal to add or edit the portlets
