### PR TITLE
Move collective.testcaselayer to a test dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.installed.cfg
+bin
+develop-eggs
+parts
+var

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+recursive-include src *
+recursive-include docs *
+include *
+global-exclude *.pyc

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -43,6 +43,6 @@ scripts = zopepy
 recipe = zc.recipe.testrunner
 eggs =
   Plone
-  qi.portlet.TagClouds
+  qi.portlet.TagClouds[test]
 defaults = ['--exit-with-status', '--auto-color', '--auto-progress','-s', 'qi.portlet.TagClouds']
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 1.34
 ----
+
+* Moved collective.testcaselayer from the install_requires to a 'test'
+  extras_require. [maurits]
 * Do not require cmf.ManagePortal to add or edit the portlet [erral]
 
 1.33

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,10 @@ setup(name='qi.portlet.TagClouds',
       zip_safe=False,
       install_requires=[
           'setuptools',
-          'collective.testcaselayer'
           # -*- Extra requirements: -*-
       ],
+      extras_require={
+          'test': ['collective.testcaselayer']},
       entry_points="""
       [z3c.autoinclude.plugin]
       target = plone


### PR DESCRIPTION
testcaselayer should not be pulled in to the eggs of the instance, only the eggs used during a test run.

Also: added .gitignore and MANIFEST.in.
